### PR TITLE
fix: update TypeScript config to use modern module resolution

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "compilerOptions": {
-    "target": "es2020",
-    "module": "commonjs",
-    "lib": ["es6"],
+    "target": "esnext",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "lib": ["esnext"],
     "allowJs": true,
     "checkJs": false,
     "outDir": "build",


### PR DESCRIPTION
- Update target from es2020 to esnext for latest JS features
- Change module system from commonjs to nodenext
- Add moduleResolution: nodenext to properly resolve ESM packages
- Update lib from es6 to esnext to match target

This resolves build errors with @rapideditor/country-coder and other modern packages that require proper ESM module resolution.