### PR TITLE
feat: implement property staking pool type on OceanpointTokenInformat…

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -126,7 +126,6 @@ contracts:
     handler: src/handler/ZeroEx.ts
     events:
       - event: LimitOrderFilled
-  # This is used to index mainnet for price feeds
   - name: PriceFeedRegistry
     abi_file_path: ./abis/PriceFeedRegistry.json
     handler: src/handler/PriceFeedRegistryHandler.ts
@@ -137,72 +136,55 @@ contracts:
     handler: src/handler/PriceFeedDataHandler.ts
     events:
       - event: AnswerUpdated
-unordered_multichain_mode: false
 networks:
-  ### START PRICE FEED SECTION  ###
-  # We fetch the prices of BST and other currencies directly from mainnet as they are not available on testnet
-  # Comment this section out if you want fast sync for testing without fetching prices
   - id: 1
-    start_block: 0
-    contracts:
-      - name: PriceFeedRegistry
-        address:
-          - 0x47fb2585d2c56fe188d0e6ec628a38b74fceeedf
-      - name: UniswapPoolV2
-        address:
-          # Mainnet BST/ETH pool
-          - 0x0e85fb1be698e777f2185350b4a52e5ee8df51a6
-      - name: PriceDataFeed
-
-  ### END PRICE FEED SECTION ###
-
-  ### START ECOSYSTEM NETWORK SPECIFIC SECTION ###
-  - id: 11155111
     start_block: 0
     contracts:
       - name: BlocksquareToken
         address:
-          - 0x7000Ec7486d8c6f9bd9FfA930f9ACE2D9564d02b
+          - 0x509A38b7a1cC0dcd83Aa9d06214663D9eC7c7F4a
       - name: CertifiedPartners
         address:
-          - 0x2192d72E0648277Ae50f2Ce516c5fD1B90572030
+          - 0x8DbB99cc3721f5c9cc7c9E92Db260813cf78cdd3
       - name: DataStorageProxy
         address:
-          - 0x846D955EBe2e79ae61E7B8e7f4568103f095D26F
+          - 0x8C2A858FE7b2bf155247C7F528c6CA7B186197B5
       - name: GovernancePool
         address:
-          - 0x145a6DB84aEd0Fe46E4cCB3f96930100418f00A2
+          - 0x6F1E92fb8a685AaA0710BAD194D7B1aa839F7F8a
       - name: LiquidityStakingPool
-        address: [0x0a654a300eAbDB763d860154bC72C4DD58c64AEF,0x28736062E9659FEc652ceF0608851AB2187eb54e]
+        address: [0x1802F66868d0649687A7a6bc9b8a4292e148dAEC]
       - name: MarketplacePoolFactory
         address:
-          - 0x3a0AD3e022e9CC53a75EA8C4907B6E326a615504
+          - 0x17887106a14f38Bf10512565bdBb5BD7AC12F001
       - name: MarketplacePool
       - name: OceanpointValuation
-        address: [0xd88f8CB694fB5684DEDFb68C946749D1FAE64d83,0x15389b98C8050562a6B0Ec6684DFD39F961d0DE9,0x00e63d90b0481c8AC9abE68d03ec40B2d3e87E45]
+        address: [0xAeEA40Bb8393174459C4016BCe2625076Fe4DefF,0x14db5B377d13eC9f9e7747f42D71634b5Ef5a335,0x05F5b75d80291910a54b65AEa9B45F549CDd0AcC,0x3C18b35E8E919224eA4099acC0d280Eda76A71C0]
       - name: PropertyToken
       - name: PropertyTokenOffering
         address:
-          - 0x223aD3AC5Df27F8e062A805A04996F00f1fEAcEb
+          - 0x25862c4fB4ce9d6Ff9B463488e0EC656fA08dE78
       - name: PropertyFactory
         address:
-          - 0x67b899aF3F27072f15f22Bb33E5f1dF2696CAFcB
+          - 0x1Ae91a263A690BF2129cf0b3aCAc92bBB67E6685
       - name: PropertyRegistry
         address:
-          - 0x0be43Cfd32a91cC277489b547598b6428ef9A584
+          - 0x05325C1Ab1440df7214dB38F676F95999729267B
       - name: PropertyRevenueDistribution
         address:
-          - 0xbc9bf93d96096F42364DBD2c2b32a317fd06C8cB
+          - 0xBcb1757cDAdeC25B6cAdC1A83953A70eDa2Da8cb
       - name: PropertyStakingPool
-        address: [0x00C92C11dB2E4229291398000132c3Cfdd4Daac1,0xEA819503da30628F862e1D9F5944aD5d3e347A96,0x9CaE63f8e6b931D269A449A937F742a5d1B3A4A9]
+        address: [0x13299657e662894b933Bb3Ee73F7f8dA94b55451,0x57ba886442d248C2E7a3a5826F2b183A22eCc73e,0x6f5eCF8a8DADAAC3c8440A080c9271f845f34b07,0xFC7cd245913691Fb2d305a0fc60A1DadD1eCdeBF]
+      - name: UniswapPoolV2
+        address: [0x0E85fB1be698E777F2185350b4A52E5eE8DF51A6]
       - name: Users
         address:
-          - 0xCd0c1845552DD0b2EFCBa0cF0ECd341A0B99d49a
+          - 0x13344D0Cb96b17dF81C4171Ce47E14ff6c1975f7
       - name: ZeroEx
         address:
           - 0xDef1C0ded9bec7F1a1670819833240f027b25EfF
-        start_block: 0
-      - name: UniswapPoolV2
-        address: [0xc026cBA28A7f94C8Bc16547e979295191b2FD671,0x0E85fB1be698E777F2185350b4A52E5eE8DF51A6]
-
-  ### END ECOSYSTEM NETWORK SPECIFIC SECTION ###
+        start_block: 17337444
+      - name: PriceFeedRegistry
+        address:
+          - 0x47fb2585d2c56fe188d0e6ec628a38b74fceeedf
+      - name: PriceDataFeed

--- a/config.yaml
+++ b/config.yaml
@@ -126,6 +126,7 @@ contracts:
     handler: src/handler/ZeroEx.ts
     events:
       - event: LimitOrderFilled
+  # This is used to index mainnet for price feeds
   - name: PriceFeedRegistry
     abi_file_path: ./abis/PriceFeedRegistry.json
     handler: src/handler/PriceFeedRegistryHandler.ts
@@ -136,55 +137,72 @@ contracts:
     handler: src/handler/PriceFeedDataHandler.ts
     events:
       - event: AnswerUpdated
+unordered_multichain_mode: false
 networks:
+  ### START PRICE FEED SECTION  ###
+  # We fetch the prices of BST and other currencies directly from mainnet as they are not available on testnet
+  # Comment this section out if you want fast sync for testing without fetching prices
   - id: 1
+    start_block: 0
+    contracts:
+      - name: PriceFeedRegistry
+        address:
+          - 0x47fb2585d2c56fe188d0e6ec628a38b74fceeedf
+      - name: UniswapPoolV2
+        address:
+          # Mainnet BST/ETH pool
+          - 0x0e85fb1be698e777f2185350b4a52e5ee8df51a6
+      - name: PriceDataFeed
+
+  ### END PRICE FEED SECTION ###
+
+  ### START ECOSYSTEM NETWORK SPECIFIC SECTION ###
+  - id: 11155111
     start_block: 0
     contracts:
       - name: BlocksquareToken
         address:
-          - 0x509A38b7a1cC0dcd83Aa9d06214663D9eC7c7F4a
+          - 0x7000Ec7486d8c6f9bd9FfA930f9ACE2D9564d02b
       - name: CertifiedPartners
         address:
-          - 0x8DbB99cc3721f5c9cc7c9E92Db260813cf78cdd3
+          - 0x2192d72E0648277Ae50f2Ce516c5fD1B90572030
       - name: DataStorageProxy
         address:
-          - 0x8C2A858FE7b2bf155247C7F528c6CA7B186197B5
+          - 0x846D955EBe2e79ae61E7B8e7f4568103f095D26F
       - name: GovernancePool
         address:
-          - 0x6F1E92fb8a685AaA0710BAD194D7B1aa839F7F8a
+          - 0x145a6DB84aEd0Fe46E4cCB3f96930100418f00A2
       - name: LiquidityStakingPool
-        address: [0x1802F66868d0649687A7a6bc9b8a4292e148dAEC]
+        address: [0x0a654a300eAbDB763d860154bC72C4DD58c64AEF,0x28736062E9659FEc652ceF0608851AB2187eb54e]
       - name: MarketplacePoolFactory
         address:
-          - 0x17887106a14f38Bf10512565bdBb5BD7AC12F001
+          - 0x3a0AD3e022e9CC53a75EA8C4907B6E326a615504
       - name: MarketplacePool
       - name: OceanpointValuation
-        address: [0xAeEA40Bb8393174459C4016BCe2625076Fe4DefF,0x14db5B377d13eC9f9e7747f42D71634b5Ef5a335,0x05F5b75d80291910a54b65AEa9B45F549CDd0AcC,0x3C18b35E8E919224eA4099acC0d280Eda76A71C0]
+        address: [0x00e63d90b0481c8AC9abE68d03ec40B2d3e87E45,0xd88f8CB694fB5684DEDFb68C946749D1FAE64d83,0x15389b98C8050562a6B0Ec6684DFD39F961d0DE9]
       - name: PropertyToken
       - name: PropertyTokenOffering
         address:
-          - 0x25862c4fB4ce9d6Ff9B463488e0EC656fA08dE78
+          - 0x223aD3AC5Df27F8e062A805A04996F00f1fEAcEb
       - name: PropertyFactory
         address:
-          - 0x1Ae91a263A690BF2129cf0b3aCAc92bBB67E6685
+          - 0x67b899aF3F27072f15f22Bb33E5f1dF2696CAFcB
       - name: PropertyRegistry
         address:
-          - 0x05325C1Ab1440df7214dB38F676F95999729267B
+          - 0x0be43Cfd32a91cC277489b547598b6428ef9A584
       - name: PropertyRevenueDistribution
         address:
-          - 0xBcb1757cDAdeC25B6cAdC1A83953A70eDa2Da8cb
+          - 0xbc9bf93d96096F42364DBD2c2b32a317fd06C8cB
       - name: PropertyStakingPool
-        address: [0x13299657e662894b933Bb3Ee73F7f8dA94b55451,0x57ba886442d248C2E7a3a5826F2b183A22eCc73e,0x6f5eCF8a8DADAAC3c8440A080c9271f845f34b07,0xFC7cd245913691Fb2d305a0fc60A1DadD1eCdeBF]
-      - name: UniswapPoolV2
-        address: [0x0E85fB1be698E777F2185350b4A52E5eE8DF51A6]
+        address: [0x9CaE63f8e6b931D269A449A937F742a5d1B3A4A9,0x00C92C11dB2E4229291398000132c3Cfdd4Daac1,0xEA819503da30628F862e1D9F5944aD5d3e347A96]
       - name: Users
         address:
-          - 0x13344D0Cb96b17dF81C4171Ce47E14ff6c1975f7
+          - 0xCd0c1845552DD0b2EFCBa0cF0ECd341A0B99d49a
       - name: ZeroEx
         address:
           - 0xDef1C0ded9bec7F1a1670819833240f027b25EfF
-        start_block: 17337444
-      - name: PriceFeedRegistry
-        address:
-          - 0x47fb2585d2c56fe188d0e6ec628a38b74fceeedf
-      - name: PriceDataFeed
+        start_block: 0
+      - name: UniswapPoolV2
+        address: [0xc026cBA28A7f94C8Bc16547e979295191b2FD671,0x0E85fB1be698E777F2185350b4A52E5eE8DF51A6]
+
+  ### END ECOSYSTEM NETWORK SPECIFIC SECTION ###

--- a/schema.graphql
+++ b/schema.graphql
@@ -9,6 +9,13 @@ type Global {
   activePropertiesCountryCount: Int!
 }
 
+enum PropertyStakingPoolType {
+    COMMUNITY
+    ISSUER
+    RWA
+    LANDHIVE
+}
+
 ### Price Tracking ###
 
 type AssetPairPrice @entity {
@@ -303,6 +310,7 @@ type OceanpointTokenInformation {
   chainId: Int!
   propertyToken: PropertyToken!
   propertyStakingPool: PropertyStakingPool!
+  propertyStakingPoolType: PropertyStakingPoolType!
   propertyStakingPoolPositions: [PropertyStakingPoolPosition!]!
     @derivedFrom(field: "tokenInformation")
   valuation: BigInt!

--- a/src/config/mainnet.ts
+++ b/src/config/mainnet.ts
@@ -1,5 +1,6 @@
 import { getAddress } from 'ethers';
 import { Config } from '../types/config';
+import { PropertyStakingPoolType } from '../types/enums';
 
 export const mainnetConfig: Config = {
   chainId: 1,
@@ -39,13 +40,15 @@ export const mainnetConfig: Config = {
       valuationAddress: getAddress(
         '0xaeea40bb8393174459c4016bce2625076fe4deff'
       ),
+      type: PropertyStakingPoolType.COMMUNITY,
     },
-    // Owner Staking Pool
+    // Issuer Staking Pool
     {
       address: getAddress('0x57ba886442d248c2e7a3a5826f2b183a22ecc73e'),
       valuationAddress: getAddress(
         '0x14db5b377d13ec9f9e7747f42d71634b5ef5a335'
       ),
+      type: PropertyStakingPoolType.ISSUER,
     },
     //RWA Technology Pool
     {
@@ -53,6 +56,15 @@ export const mainnetConfig: Config = {
       valuationAddress: getAddress(
         '0x05F5b75d80291910a54b65AEa9B45F549CDd0AcC'
       ),
+      type: PropertyStakingPoolType.RWA,
+    },
+    // Landhive
+    {
+      address: getAddress('0xFC7cd245913691Fb2d305a0fc60A1DadD1eCdeBF'),
+      valuationAddress: getAddress(
+      '0x3C18b35E8E919224eA4099acC0d280Eda76A71C0'
+      ),
+      type: PropertyStakingPoolType.LANDHIVE,
     },
   ],
   propertyTokenOfferingAddress: getAddress(

--- a/src/config/testnet.ts
+++ b/src/config/testnet.ts
@@ -1,5 +1,6 @@
 import { getAddress } from 'ethers';
 import { Config } from '../types/config';
+import {PropertyStakingPoolType} from "../types/enums";
 
 export const testnetConfig: Config = {
   chainId: 11155111, // Sepolia
@@ -35,25 +36,30 @@ export const testnetConfig: Config = {
     '0xbc9bf93d96096F42364DBD2c2b32a317fd06C8cB'
   ),
   propertyStakingContracts: [
-    // Owner Staking Pool
+      // Community Staking Pool
+    {
+       address: getAddress('0x9CaE63f8e6b931D269A449A937F742a5d1B3A4A9'),
+       valuationAddress: getAddress(
+           '0x00e63d90b0481c8AC9abE68d03ec40B2d3e87E45'
+       ),
+       type: PropertyStakingPoolType.COMMUNITY,
+    },
+    // Issuer Staking Pool
     {
       address: getAddress('0x00c92c11db2e4229291398000132c3cfdd4daac1'),
       valuationAddress: getAddress(
         '0xd88f8cb694fb5684dedfb68c946749d1fae64d83'
       ),
+      type: PropertyStakingPoolType.ISSUER,
     },
+
     // CryptoSnacks Staking Pool
     {
       address: getAddress('0xea819503da30628f862e1d9f5944ad5d3e347a96'),
       valuationAddress: getAddress(
         '0x15389b98c8050562a6b0ec6684dfd39f961d0de9'
       ),
-    },
-    {
-      address: getAddress('0x9CaE63f8e6b931D269A449A937F742a5d1B3A4A9'),
-      valuationAddress: getAddress(
-        '0x00e63d90b0481c8AC9abE68d03ec40B2d3e87E45'
-      ),
+      type: PropertyStakingPoolType.RWA,
     },
   ],
   propertyTokenOfferingAddress: getAddress(

--- a/src/handler/OceanpointValuation.ts
+++ b/src/handler/OceanpointValuation.ts
@@ -1,6 +1,9 @@
 import { OceanpointValuation } from 'generated';
 import { getNewOceanpointTokenInformation } from '../helper/OceanpointTokenValuation';
-import { getStakingPoolAddressFromValuationAddress } from '../helper/PropertyStakingPool';
+import {
+    getStakingPoolAddressFromValuationAddress,
+    getStakingPoolTypeFromValuationAddress
+} from '../helper/PropertyStakingPool';
 import {BIGINT_100K} from "../helper/constants";
 
 OceanpointValuation.ValuationUpdate.handler(async ({ event, context }) => {
@@ -8,12 +11,17 @@ OceanpointValuation.ValuationUpdate.handler(async ({ event, context }) => {
     event.srcAddress
   );
 
+  const stakingPoolType = getStakingPoolTypeFromValuationAddress(
+      event.srcAddress
+   );
+
   const valuation = await context.OceanpointTokenInformation.getOrCreate(
     getNewOceanpointTokenInformation(
       event.chainId,
       event.params.property,
       event.srcAddress,
-      stakingPoolAdddress
+      stakingPoolAdddress,
+      stakingPoolType
     )
   );
 
@@ -24,6 +32,7 @@ OceanpointValuation.ValuationUpdate.handler(async ({ event, context }) => {
     valuation: event.params.newValuation,
     valuationFrom: event.srcAddress,
     valuePerBSPT,
+    propertyStakingPoolType: stakingPoolType,
   });
 });
 
@@ -32,17 +41,23 @@ OceanpointValuation.APYUpdate.handler(async ({ event, context }) => {
     event.srcAddress
   );
 
+  const stakingPoolType = getStakingPoolTypeFromValuationAddress(
+      event.srcAddress
+  );
+
   const valuation = await context.OceanpointTokenInformation.getOrCreate(
     getNewOceanpointTokenInformation(
       event.chainId,
       event.params.property,
       event.srcAddress,
-      stakingPoolAdddress
+      stakingPoolAdddress,
+      stakingPoolType
     )
   );
 
   context.OceanpointTokenInformation.set({
     ...valuation,
     apy: event.params.newAPY,
+    propertyStakingPoolType: stakingPoolType,
   });
 });

--- a/src/helper/OceanpointTokenValuation.ts
+++ b/src/helper/OceanpointTokenValuation.ts
@@ -1,10 +1,12 @@
 import { OceanpointTokenInformation } from 'generated';
+import {PropertyStakingPoolType} from "../types/enums";
 
 export const getNewOceanpointTokenInformation = (
   chainId: number,
   propertyAddress: string,
   contractAddress: string,
-  propertyStakingContractAddress: string
+  propertyStakingContractAddress: string,
+  poolType: PropertyStakingPoolType
 ): OceanpointTokenInformation => {
   return {
     id: `${chainId}-${propertyAddress}-${contractAddress}`,
@@ -15,5 +17,6 @@ export const getNewOceanpointTokenInformation = (
     propertyStakingPool_id: `${chainId}-${propertyStakingContractAddress}`,
     propertyToken_id: `${chainId}-${propertyAddress}`,
     valuePerBSPT: 0n,
+    propertyStakingPoolType: poolType,
   };
 };

--- a/src/helper/PropertyStakingPool.ts
+++ b/src/helper/PropertyStakingPool.ts
@@ -100,13 +100,15 @@ export function getValuationAddressForPropertyStakingPool(
 ): string {
   const poolAddressFormatted = getAddress(poolAddress);
 
-  const valuationAddress = getLoadedConfig().propertyStakingContracts.find(
+  const propertyStakingPool = getLoadedConfig().propertyStakingContracts.find(
     (contract) => contract.address === poolAddressFormatted
-  )?.valuationAddress;
+  );
 
-  if (!valuationAddress) throw new Error('Valuation address not found');
+  if (!propertyStakingPool) {
+       throw new Error(`Property staking contract not found for staking pool address: ${poolAddressFormatted}`);
+  }
 
-  return valuationAddress;
+  return propertyStakingPool.valuationAddress;
 }
 
 export function getStakingPoolAddressFromValuationAddress(
@@ -114,13 +116,15 @@ export function getStakingPoolAddressFromValuationAddress(
 ): string {
   const valuationAddressFormatted = getAddress(valuationAddress);
 
-  const stakingPoolAddress = getLoadedConfig().propertyStakingContracts.find(
+  const propertyStakingPool = getLoadedConfig().propertyStakingContracts.find(
     (contract) => contract.valuationAddress === valuationAddressFormatted
-  )?.address;
+  );
 
-  if (!stakingPoolAddress) throw new Error('Staking pool address not found');
+  if (!propertyStakingPool) {
+      throw new Error(`Property staking contract not found for valuation address: ${valuationAddressFormatted}`);
+  }
 
-  return stakingPoolAddress;
+  return propertyStakingPool.address;
 }
 
 export function getStakingPoolTypeFromValuationAddress(
@@ -128,11 +132,13 @@ export function getStakingPoolTypeFromValuationAddress(
 ): PropertyStakingPoolType {
     const valuationAddressFormatted = getAddress(valuationAddress);
 
-    const stakingPoolType = getLoadedConfig().propertyStakingContracts.find(
+    const propertyStakingPool = getLoadedConfig().propertyStakingContracts.find(
         (contract) => contract.valuationAddress === valuationAddressFormatted
-    )?.type;
+    );
 
-    if (!stakingPoolType) throw new Error('Staking pool type not found');
+    if (!propertyStakingPool) {
+        throw new Error(`Property staking contract not found for valuation address: ${valuationAddressFormatted}`);
+    }
 
-    return stakingPoolType;
+    return propertyStakingPool.type;
 }

--- a/src/helper/PropertyStakingPool.ts
+++ b/src/helper/PropertyStakingPool.ts
@@ -9,6 +9,7 @@ import {
 import { getDay, getHour } from './date';
 import { getLoadedConfig } from '../config';
 import { PropertyStakingPool } from 'generated/src/Types.gen';
+import { PropertyStakingPoolType } from '../types/enums';
 export const getNewPropertyStakingPool = (
   chainId: number,
   poolId: string
@@ -120,4 +121,18 @@ export function getStakingPoolAddressFromValuationAddress(
   if (!stakingPoolAddress) throw new Error('Staking pool address not found');
 
   return stakingPoolAddress;
+}
+
+export function getStakingPoolTypeFromValuationAddress(
+    valuationAddress: string
+): PropertyStakingPoolType {
+    const valuationAddressFormatted = getAddress(valuationAddress);
+
+    const stakingPoolType = getLoadedConfig().propertyStakingContracts.find(
+        (contract) => contract.valuationAddress === valuationAddressFormatted
+    )?.type;
+
+    if (!stakingPoolType) throw new Error('Staking pool type not found');
+
+    return stakingPoolType;
 }

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -18,7 +18,7 @@ export type Config = {
   propertyStakingContracts: Array<{
     address: string;
     valuationAddress: string;
-    type?: PropertyStakingPoolType;
+    type: PropertyStakingPoolType;
   }>;
   uniswapPoolContracts: Array<{
     assetPairId: string;

--- a/src/types/config.ts
+++ b/src/types/config.ts
@@ -1,4 +1,5 @@
 import { Dayjs } from "dayjs";
+import { PropertyStakingPoolType } from "./enums";
 
 export type Config = {
   chainId: number;
@@ -17,6 +18,7 @@ export type Config = {
   propertyStakingContracts: Array<{
     address: string;
     valuationAddress: string;
+    type?: PropertyStakingPoolType;
   }>;
   uniswapPoolContracts: Array<{
     assetPairId: string;

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -1,0 +1,7 @@
+export enum PropertyStakingPoolType {
+  COMMUNITY = "COMMUNITY",
+  ISSUER = "ISSUER",
+  RWA = "RWA",
+  LANDHIVE = "LANDHIVE",
+}
+


### PR DESCRIPTION
This pull request introduces support for categorizing property staking pools by type throughout the codebase. It adds a new `PropertyStakingPoolType` enum, updates configuration files and types to include this categorization, and ensures that staking pool type information is tracked and stored in relevant data structures and events.

**Enums**
- Introduced the `PropertyStakingPoolType` enum in `src/types/enums.ts` to centralize staking pool type definitions.

**Landhive pool**
- Included the Landhive pool to be indexed